### PR TITLE
Update macOS to 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # maybe update to macOS 14 if this is ARM64-ready?
-        platform: [macos-13, ubuntu-20.04, windows-2022]
+        platform: [macos-15, ubuntu-20.04, windows-2022]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -87,7 +86,7 @@ jobs:
           path: src-tauri/target/release/fabulously-optimized-installer
       - name: Upload the macOS packages
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'macos-13'
+        if: matrix.platform == 'macos-15'
         with:
           name: macos-packages
           path: src-tauri/target/release/bundle/dmg/*.dmg
@@ -117,7 +116,7 @@ jobs:
           path: src-tauri/target/debug/fabulously-optimized-installer
       - name: Upload the macOS packages (debug)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'macos-13'
+        if: matrix.platform == 'macos-15'
         with:
           name: macos-packages-debug
           path: src-tauri/target/debug/bundle/dmg/*.dmg


### PR DESCRIPTION
~~macOS 15.x in the GitHub Actions page is marked as AMD64 supported which means we don't need to freeze to 13.x permanently.~~ `windows-2025` on other hand is not available yet as the devs are [currently working on it](https://github.com/actions/runner-images/issues/10806#issuecomment-2479517152).