### PR TITLE
Update Ubuntu to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         # maybe update to macOS 14 if this is ARM64-ready?
-        platform: [macos-13, ubuntu-20.04, windows-2022]
+        platform: [macos-13, ubuntu-22.04, windows-2022]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: Deploy Rust to CI
         uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies (Ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
@@ -74,13 +74,13 @@ jobs:
           RUSTC_WRAPPER: 'sccache'
       - name: Upload the Linux packages (AppImage)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         with:
           name: linux-packages
           path: src-tauri/target/release/bundle/appimage/*.AppImage
       - name: Upload the Linux packages (ELF)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         with:
           name: linux-packages-raw
           # TODO: a better way to find just the binary
@@ -104,13 +104,13 @@ jobs:
           RUSTC_WRAPPER: 'sccache'
       - name: Upload the Linux packages (AppImage, debug)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         with:
           name: linux-packages-debug
           path: src-tauri/target/debug/bundle/appimage/*.AppImage
       - name: Upload the Linux packages (ELF, debug)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         with:
           name: linux-packages-raw-debug
           # TODO: a better way to find just the binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -41,6 +43,8 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Download Verifier
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Ubuntu 20.04 has been [deprecated](https://github.com/actions/runner-images/issues/11101) and is to be killed off in 2025-04-01, Consider merging this at some point to avoid causing the linux compilation to fail in future. `windows-2025` on other hand is being worked on and will be PRed sometime later.