### PR TITLE
macOS 15, Bump dependencies in actions

### DIFF
--- a/.github/workflows/build-signed.yml
+++ b/.github/workflows/build-signed.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: latest
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
       - name: Deploy Rust to CI
@@ -40,7 +40,7 @@ jobs:
           name: windows-packages-unsigned
           path: src-tauri/target/release/Fabulously Optimized Installer.exe
       - name: Submit Signing Request
-        uses: signpath/github-action-submit-signing-request@v0.4
+        uses: signpath/github-action-submit-signing-request@v1.3
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '903dc541-2740-462e-b9dd-659adaf2188e'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           cache-dependency-path: verifier/go.sum
       - name: Build Verifier
@@ -34,15 +34,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # maybe update to macOS 14 if this is ARM64-ready?
-        platform: [macos-13, ubuntu-22.04, windows-2025]
+        # Note: macOS 26 image does not support x86-64, Bump if we are ARM64-ready.
+        platform: [macos-15-intel, ubuntu-22.04, windows-2025]
 
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Download Verifier
@@ -54,11 +54,11 @@ jobs:
         if: matrix.platform != 'windows-2025'
         run: chmod +x verifier/dist/*
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: latest
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: 'pnpm'
@@ -91,7 +91,7 @@ jobs:
           path: src-tauri/target/release/fabulously-optimized-installer
       - name: Upload the macOS packages
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'macos-13'
+        if: matrix.platform == 'macos-15-intel'
         with:
           name: macos-packages
           path: src-tauri/target/release/bundle/dmg/*.dmg
@@ -121,7 +121,7 @@ jobs:
           path: src-tauri/target/debug/fabulously-optimized-installer
       - name: Upload the macOS packages (debug)
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'macos-13'
+        if: matrix.platform == 'macos-15-intel'
         with:
           name: macos-packages-debug
           path: src-tauri/target/debug/bundle/dmg/*.dmg


### PR DESCRIPTION
1. Bumps macOS from `macos-13` -> `macos-15-intel` which is the last x86-64 image to be supported by GitHub themselves.
2. Bumps job dependencies in actions.