### PR TITLE
Bump nodejs to 20, Freeze Go version

### DIFF
--- a/.github/workflows/build-signed.yml
+++ b/.github/workflows/build-signed.yml
@@ -14,6 +14,9 @@ jobs:
           persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@v6
+        with:
+          go-version: '1.22'
+          check-latest: true
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/build-signed.yml
+++ b/.github/workflows/build-signed.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: '20'
       - name: Deploy Rust to CI
         uses: dtolnay/rust-toolchain@stable
       - name: Deploy frontend dependencies

--- a/.github/workflows/build-signed.yml
+++ b/.github/workflows/build-signed.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
       - name: Deploy Rust to CI
         uses: dtolnay/rust-toolchain@stable
       - name: Deploy frontend dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           cache-dependency-path: verifier/go.sum
+          go-version: '1.22'
+          check-latest: true
       - name: Build Verifier
         run: |
           pushd verifier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
       - name: Deploy Rust to CI
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: '20'
           cache: 'pnpm'
       - name: Deploy Rust to CI
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
1. Resolves an issue where `./parser.linux-x64-gu.node` could not be found as an module in Node,
2. Freezes Go version to 1.22.x to avoid falling back to pre-installed version.